### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM golang:1.17-alpine as builder
-WORKDIR /go/src/couchlock
-RUN apk --no-cache add git
-COPY *.go go.mod ./
-RUN go build -v
-
 FROM alpine:3.13
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /go/src/couchlock/couchlock /usr/bin/
-
-ENTRYPOINT ["couchlock"]
+COPY couchlock /usr/bin/
+ENTRYPOINT ["/usr/bin/couchlock"]


### PR DESCRIPTION
Thanks to goreleaser we can just copy the binary into the image instead
of building it.